### PR TITLE
refactor startup to allow passing cmdline args to snapteld

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM intelsdi/snap:xenial
 
 RUN apt-get update && apt-get -y install netcat-traditional sysstat curl
 
+ENV SNAP_LOG_PATH=""
 ENV PLUGIN_URL=https://s3-us-west-2.amazonaws.com/snap.ci.snap-telemetry.io/plugins
 
 RUN for p in collector-cpu collector-interface collector-iostat collector-load collector-meminfo publisher-graphite; do \
@@ -12,5 +13,11 @@ COPY plugins/snap-plugin-collector-docker plugins/snap-plugin-collector-kubestat
 COPY snapteld.conf /etc/snap/snapteld.conf
 
 COPY start.sh /usr/local/bin
-RUN mkdir /opt/snap/tasks && chmod a+x /opt/snap/tasks && chmod a+x /opt/snap/bin/* && chmod a+x /opt/snap/sbin/* && chmod a+x /opt/snap/plugins/*
-CMD /usr/local/bin/start.sh
+RUN mkdir /opt/snap/tasks && \
+    chmod a+x /opt/snap/tasks && \
+    chmod a+x /opt/snap/bin/* && \
+    chmod a+x /opt/snap/sbin/* && \
+    chmod a+x /opt/snap/plugins/*
+
+ENTRYPOINT ["/usr/local/bin/start.sh"]
+CMD ["/opt/snap/sbin/snapteld"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=v20
+VERSION=v21
 REPO=raintank
 all: build
 

--- a/README.md
+++ b/README.md
@@ -71,10 +71,8 @@ spec:
       - env:
         - name: PROCFS_MOUNT
           value: /proc_host
-        - name: LISTEN_PORT
+        - name: SNAP_PORT
           value: "8181"
-        - name: SNAP_URL
-          value: "http://localhost:8181"
         image: raintank/snap_k8s:latest
         imagePullPolicy: Always
         name: snap

--- a/start.sh
+++ b/start.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-
-LISTEN_PORT=${LISTEN_PORT:-8181}
-sed -e "s/port: 8181/port: $LISTEN_PORT/" -i /etc/snap/snapteld.conf
-
 function getNodeName {
   NODE_NAME=${NODE_NAME:-$(hostname)}
   echo $NODE_NAME | sed -e "s/\./_/g"
@@ -21,4 +17,4 @@ if [ "$(ls -A /opt/snap/tasks/)" ]; then
 fi
 
 # run SNAPTELD
-exec /opt/snap/sbin/snapteld -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} -o ''
+exec $@


### PR DESCRIPTION
- Strip the start.sh script to just parse our task templates.
- Use default SNAP environment vars for config items.